### PR TITLE
[#14] Feat: 메인 페이지 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ky": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.2"
+    "react-router-dom": "^6.21.2",
+    "react-tabs": "^6.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
           20: { value: "#F4ECD4" },
           45: { value: "#E8E3D2" },
           60: { value: "#EEE2BE" },
+          80: { value: "#EADCB1" },
           100: { value: "#F8D97E" },
         },
         secondary: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   react-router-dom:
     specifier: ^6.21.2
     version: 6.21.2(react-dom@18.2.0)(react@18.2.0)
+  react-tabs:
+    specifier: ^6.0.2
+    version: 6.0.2(react@18.2.0)
 
 devDependencies:
   '@commitlint/cli':
@@ -2122,6 +2125,11 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /clsx@2.1.0:
+    resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /code-block-writer@12.0.0:
     resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
     dev: true
@@ -3963,6 +3971,11 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
@@ -4284,6 +4297,14 @@ packages:
     hasBin: true
     dev: true
 
+  /prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+    dev: false
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4306,6 +4327,10 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
 
   /react-refresh@0.14.0:
@@ -4333,6 +4358,16 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.14.2
+      react: 18.2.0
+    dev: false
+
+  /react-tabs@6.0.2(react@18.2.0):
+    resolution: {integrity: sha512-aQXTKolnM28k3KguGDBSAbJvcowOQr23A+CUJdzJtOSDOtTwzEaJA+1U4KwhNL9+Obe+jFS7geuvA7ICQPXOnQ==}
+    peerDependencies:
+      react: ^18.0.0
+    dependencies:
+      clsx: 2.1.0
+      prop-types: 15.8.1
       react: 18.2.0
     dev: false
 

--- a/src/components/common/Tteokguks/TteokgukCard.tsx
+++ b/src/components/common/Tteokguks/TteokgukCard.tsx
@@ -1,18 +1,16 @@
 import { css } from "@styled-system/css";
 
 import tteokgukIncomplete from "@/assets/images/tteokguk-incomplete.png";
-import { Link } from "@/routes/Link";
 
 interface Props {
-  id: number;
   tteokgukNumber: number;
   nickname: string;
   hasBadge?: boolean;
 }
 
-const TteokgukCard = ({ id, tteokgukNumber, nickname, hasBadge }: Props) => {
+const TteokgukCard = ({ tteokgukNumber, nickname, hasBadge }: Props) => {
   return (
-    <Link to={`/tteokguks/${id}`} className={styles.container}>
+    <div className={styles.container}>
       {hasBadge && <div className={styles.badge}>응원요청</div>}
       <div className={styles.imageContainer}>
         <img src={tteokgukIncomplete} alt="미완성된 떡국" />
@@ -21,7 +19,7 @@ const TteokgukCard = ({ id, tteokgukNumber, nickname, hasBadge }: Props) => {
         <div className={styles.cardTitle}>{tteokgukNumber}번째 소원떡국</div>
         <div className={styles.cardNickname}>@ {nickname}</div>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/src/components/common/Tteokguks/TteokgukCard.tsx
+++ b/src/components/common/Tteokguks/TteokgukCard.tsx
@@ -1,16 +1,18 @@
 import { css } from "@styled-system/css";
 
 import tteokgukIncomplete from "@/assets/images/tteokguk-incomplete.png";
+import { Link } from "@/routes/Link";
 
 interface Props {
+  id: number;
   tteokgukNumber: number;
   nickname: string;
   hasBadge?: boolean;
 }
 
-const TteokgukCard = ({ tteokgukNumber, nickname, hasBadge }: Props) => {
+const TteokgukCard = ({ id, tteokgukNumber, nickname, hasBadge }: Props) => {
   return (
-    <div className={styles.container}>
+    <Link to={`/tteokguks/${id}`} className={styles.container}>
       {hasBadge && <div className={styles.badge}>응원요청</div>}
       <div className={styles.imageContainer}>
         <img src={tteokgukIncomplete} alt="미완성된 떡국" />
@@ -19,7 +21,7 @@ const TteokgukCard = ({ tteokgukNumber, nickname, hasBadge }: Props) => {
         <div className={styles.cardTitle}>{tteokgukNumber}번째 소원떡국</div>
         <div className={styles.cardNickname}>@ {nickname}</div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/common/Tteokguks/TteokgukCard.tsx
+++ b/src/components/common/Tteokguks/TteokgukCard.tsx
@@ -1,0 +1,71 @@
+import { css } from "@styled-system/css";
+
+import tteokgukIncomplete from "@/assets/images/tteokguk-incomplete.png";
+
+interface Props {
+  tteokgukNumber: number;
+  nickname: string;
+  hasBadge?: boolean;
+}
+
+const TteokgukCard = ({ tteokgukNumber, nickname, hasBadge }: Props) => {
+  return (
+    <div className={styles.container}>
+      {hasBadge && <div className={styles.badge}>응원요청</div>}
+      <div className={styles.imageContainer}>
+        <img src={tteokgukIncomplete} alt="미완성된 떡국" />
+      </div>
+      <div className={styles.cardContent}>
+        <div className={styles.cardTitle}>{tteokgukNumber}번째 소원떡국</div>
+        <div className={styles.cardNickname}>@ {nickname}</div>
+      </div>
+    </div>
+  );
+};
+
+export default TteokgukCard;
+
+const styles = {
+  container: css({
+    position: "relative",
+    maxWidth: "calc(50% - 1.6rem)",
+    width: "100%",
+    height: "20.5rem",
+    boxSizing: "border-box",
+    borderRadius: "1rem",
+    overflow: "hidden",
+  }),
+  badge: css({
+    position: "absolute",
+    top: "0.7rem",
+    right: "0.6rem",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: "4.7rem",
+    height: "2rem",
+    fontSize: "1rem",
+    borderRadius: "0.8rem",
+    backgroundColor: "secondary.50",
+  }),
+  imageContainer: css({
+    display: "flex",
+    justifyContent: "center",
+    height: "15.2rem",
+    backgroundColor: "white",
+    overflow: "hidden",
+  }),
+  cardContent: css({
+    width: "100%",
+    height: "5.3rem",
+    backgroundColor: "primary.80",
+    padding: "0.8rem 1rem 0",
+  }),
+  cardTitle: css({
+    fontSize: "1.4rem",
+    fontWeight: 700,
+  }),
+  cardNickname: css({
+    fontSize: "1.2rem",
+  }),
+};

--- a/src/components/common/Tteokguks/TteokgukList.tsx
+++ b/src/components/common/Tteokguks/TteokgukList.tsx
@@ -2,11 +2,15 @@ import { css } from "@styled-system/css";
 
 import TteokgukCard from "./TteokgukCard";
 
+import { Link } from "@/routes/Link";
+
 const TteokgukList = () => {
   return (
     <ul className={styles.container}>
       {[...Array(12)].map((_, index) => (
-        <TteokgukCard id={index} tteokgukNumber={1178} nickname="재민" />
+        <Link to={`/tteokguks/${index}`}>
+          <TteokgukCard tteokgukNumber={1178} nickname="재민" />
+        </Link>
       ))}
     </ul>
   );

--- a/src/components/common/Tteokguks/TteokgukList.tsx
+++ b/src/components/common/Tteokguks/TteokgukList.tsx
@@ -1,0 +1,23 @@
+import { css } from "@styled-system/css";
+
+import TteokgukCard from "./TteokgukCard";
+
+const TteokgukList = () => {
+  return (
+    <ul className={styles.container}>
+      {[...Array(12)].map(() => (
+        <TteokgukCard tteokgukNumber={1178} nickname="재민" />
+      ))}
+    </ul>
+  );
+};
+
+export default TteokgukList;
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexFlow: "row wrap",
+    gap: "1.6rem",
+  }),
+};

--- a/src/components/common/Tteokguks/TteokgukList.tsx
+++ b/src/components/common/Tteokguks/TteokgukList.tsx
@@ -5,8 +5,8 @@ import TteokgukCard from "./TteokgukCard";
 const TteokgukList = () => {
   return (
     <ul className={styles.container}>
-      {[...Array(12)].map(() => (
-        <TteokgukCard tteokgukNumber={1178} nickname="재민" />
+      {[...Array(12)].map((_, index) => (
+        <TteokgukCard id={index} tteokgukNumber={1178} nickname="재민" />
       ))}
     </ul>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,81 @@
+import { useState } from "react";
+import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+
+import { css } from "@styled-system/css";
+
+import TteokgukList from "@/components/common/Tteokguks/TteokgukList";
+import Button from "@/components/common/Button";
+
 const MainPage = () => {
-  return <div>떡국 리스트를 볼 수 있는 페이지입니다.</div>;
+  const [tabIndex, setTabIndex] = useState(0);
+
+  return (
+    <div className={styles.container}>
+      <Tabs selectedIndex={tabIndex} onSelect={(index) => setTabIndex(index)}>
+        <TabList className={styles.tabList}>
+          <Tab className={tabIndex === 0 ? styles.selectedTab : ""}>새로운 떡국</Tab>
+          <Tab className={tabIndex === 1 ? styles.selectedTab : ""}>완성된 떡국</Tab>
+        </TabList>
+        <TabPanel className={styles.tabPanel}>
+          <TteokgukList />
+        </TabPanel>
+        <TabPanel className={styles.tabPanel}>
+          <TteokgukList />
+        </TabPanel>
+      </Tabs>
+
+      <Button color="secondary" applyColorTo="background" className={styles.button}>
+        소원 떡국 만들기
+      </Button>
+    </div>
+  );
 };
 
 export default MainPage;
+
+const styles = {
+  container: css({
+    position: "relative",
+    height: "100%",
+    overflow: "auto",
+    _scrollbar: {
+      display: "none",
+    },
+  }),
+  tabList: css({
+    display: "flex",
+    justifyContent: "space-around",
+    fontSize: "1.6rem",
+    fontWeight: 700,
+    borderBottomWidth: "0.1rem",
+    borderBottomColor: "primary.45",
+    padding: "0.8rem 5.6rem 0.9rem",
+    cursor: "pointer",
+  }),
+  tabPanel: css({
+    display: "flex",
+    flexFlow: "column wrap",
+    marginTop: "2rem",
+    paddingLeft: "1.6rem",
+  }),
+
+  selectedTab: css({
+    position: "relative",
+    _after: {
+      content: '""',
+      position: "absolute",
+      bottom: "-0.9rem",
+      left: "50%",
+      transform: "translateX(-50%)",
+      width: "9.4rem",
+      height: "0.4rem",
+      backgroundColor: "primary.100",
+    },
+  }),
+  button: css({
+    position: "sticky",
+    width: "calc(100% - 5rem)",
+    bottom: "3rem",
+    marginX: "2.4rem",
+  }),
+};

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
+import classNames from "classnames";
+
 import { css } from "@styled-system/css";
 
 import TteokgukList from "@/components/common/Tteokguks/TteokgukList";
@@ -11,6 +13,7 @@ import headerLogo from "@/assets/images/header-logo.png";
 
 const MainPage = () => {
   const [tabIndex, setTabIndex] = useState(0);
+  const isSelectedTab = (index: number) => index === tabIndex;
 
   return (
     <>
@@ -18,10 +21,14 @@ const MainPage = () => {
         <img src={headerLogo} alt="로고" />
       </Header>
       <div className={styles.container}>
-        <Tabs selectedIndex={tabIndex} onSelect={(index) => setTabIndex(index)}>
+        <Tabs selectedIndex={tabIndex} onSelect={(index: number) => setTabIndex(index)}>
           <TabList className={styles.tabList}>
-            <Tab className={tabIndex === 0 ? styles.selectedTab : ""}>새로운 떡국</Tab>
-            <Tab className={tabIndex === 1 ? styles.selectedTab : ""}>완성된 떡국</Tab>
+            <Tab className={classNames({ [styles.selectedTab]: isSelectedTab(0) })}>
+              새로운 떡국
+            </Tab>
+            <Tab className={classNames({ [styles.selectedTab]: isSelectedTab(1) })}>
+              완성된 떡국
+            </Tab>
           </TabList>
           <TabPanel className={styles.tabPanel}>
             <TteokgukList />
@@ -57,7 +64,7 @@ const styles = {
     fontWeight: 700,
     borderBottomWidth: "0.1rem",
     borderBottomColor: "primary.45",
-    padding: "0.8rem 5.6rem 0.9rem",
+    padding: "0.8rem 0 0.9rem",
     marginBottom: "2rem",
     cursor: "pointer",
   }),

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,29 +5,37 @@ import { css } from "@styled-system/css";
 
 import TteokgukList from "@/components/common/Tteokguks/TteokgukList";
 import Button from "@/components/common/Button";
+import Header from "@/components/common/Header";
+import ProfileIcon from "@/assets/svg/profile.svg";
+import headerLogo from "@/assets/images/header-logo.png";
 
 const MainPage = () => {
   const [tabIndex, setTabIndex] = useState(0);
 
   return (
-    <div className={styles.container}>
-      <Tabs selectedIndex={tabIndex} onSelect={(index) => setTabIndex(index)}>
-        <TabList className={styles.tabList}>
-          <Tab className={tabIndex === 0 ? styles.selectedTab : ""}>새로운 떡국</Tab>
-          <Tab className={tabIndex === 1 ? styles.selectedTab : ""}>완성된 떡국</Tab>
-        </TabList>
-        <TabPanel className={styles.tabPanel}>
-          <TteokgukList />
-        </TabPanel>
-        <TabPanel className={styles.tabPanel}>
-          <TteokgukList />
-        </TabPanel>
-      </Tabs>
+    <>
+      <Header actionIcon={<ProfileIcon />}>
+        <img src={headerLogo} alt="로고" />
+      </Header>
+      <div className={styles.container}>
+        <Tabs selectedIndex={tabIndex} onSelect={(index) => setTabIndex(index)}>
+          <TabList className={styles.tabList}>
+            <Tab className={tabIndex === 0 ? styles.selectedTab : ""}>새로운 떡국</Tab>
+            <Tab className={tabIndex === 1 ? styles.selectedTab : ""}>완성된 떡국</Tab>
+          </TabList>
+          <TabPanel className={styles.tabPanel}>
+            <TteokgukList />
+          </TabPanel>
+          <TabPanel className={styles.tabPanel}>
+            <TteokgukList />
+          </TabPanel>
+        </Tabs>
 
-      <Button color="secondary" applyColorTo="background" className={styles.button}>
-        소원 떡국 만들기
-      </Button>
-    </div>
+        <Button color="secondary" applyColorTo="background" className={styles.button}>
+          소원 떡국 만들기
+        </Button>
+      </div>
+    </>
   );
 };
 
@@ -36,7 +44,7 @@ export default MainPage;
 const styles = {
   container: css({
     position: "relative",
-    height: "100%",
+    height: "calc(100% - 4.8rem)",
     overflow: "auto",
     _scrollbar: {
       display: "none",

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -74,7 +74,7 @@ const styles = {
   }),
   button: css({
     position: "sticky",
-    width: "calc(100% - 5rem)",
+    width: "calc(100% - 5.1rem)",
     bottom: "3rem",
     marginX: "2.4rem",
   }),

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -58,12 +58,12 @@ const styles = {
     borderBottomWidth: "0.1rem",
     borderBottomColor: "primary.45",
     padding: "0.8rem 5.6rem 0.9rem",
+    marginBottom: "2rem",
     cursor: "pointer",
   }),
   tabPanel: css({
     display: "flex",
     flexFlow: "column wrap",
-    marginTop: "2rem",
     paddingLeft: "1.6rem",
   }),
 


### PR DESCRIPTION
## 📝 작업 내용

메인 페이지 UI 구현했습니다.
width에 맞게 카드의 너비가 넓어지도록 했습니다.
스크롤을 내리는 경우 버튼 컴포넌트가 사라지도록 하는 것은 구현하지 못했습니다. 우선 급한 UI 작업이 끝난 후에 시도해보도록 하겠습니다!

### 📷 스크린샷
<img width="509" alt="스크린샷 2024-01-25 오전 2 50 55" src="https://github.com/tteokguk-please/tteokguk-frontend/assets/61978339/3d145c5f-2856-4d98-bded-a0451ac58e2c">


close #14 
