### PR TITLE
[#34] Feat: 회원가입 API 연동

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -32,7 +32,6 @@ export default defineConfig({
         },
         red: { 100: { value: "#F63333" } },
         green: { 100: { value: "#37C35E" } },
-        yellow: { 100: { value: "#FEE500" } },
       },
     },
     extend: {},

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import { CheckEmailNicknameResponse } from "@/types/auth";
+import { CheckEmailNicknameResponse, SignupRequest, SignupResponse } from "@/types/auth";
 import http from "./core";
 
 export const checkEmail = (email: string) => {
@@ -7,4 +7,8 @@ export const checkEmail = (email: string) => {
 
 export const checkNickname = (nickname: string) => {
   return http.get<CheckEmailNicknameResponse>(`api/v1/auth/check-nickname/${nickname}`);
+};
+
+export const postSignup = (body: SignupRequest) => {
+  return http.post<SignupResponse>("api/v1/auth/join", body);
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,10 @@
+import { CheckEmailNicknameResponse } from "@/types/auth";
+import http from "./core";
+
+export const checkEmail = (email: string) => {
+  return http.get<CheckEmailNicknameResponse>(`api/v1/auth/check-email/${email}`);
+};
+
+export const checkNickname = (nickname: string) => {
+  return http.get<CheckEmailNicknameResponse>(`api/v1/auth/check-nickname/${nickname}`);
+};

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -5,7 +5,6 @@ import { css } from "@styled-system/css";
 
 import Input from "@/components/common/Input";
 import Label from "@/components/common/Label";
-import Header from "@/components/common/Header";
 import Button from "@/components/common/Button";
 import NoCheckIcon from "@/assets/svg/no-check.svg";
 import CheckIcon from "@/assets/svg/check.svg";
@@ -111,7 +110,6 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
 
   return (
     <Fragment>
-      <Header hasPreviousPage>회원가입</Header>
       <form onSubmit={handleSubmit(onSubmit)} className={styles.container}>
         <div>
           <div className={styles.labelContainer}>

--- a/src/components/Signup/SignupForm.tsx
+++ b/src/components/Signup/SignupForm.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { css } from "@styled-system/css";
@@ -10,6 +10,8 @@ import Button from "@/components/common/Button";
 import NoCheckIcon from "@/assets/svg/no-check.svg";
 import CheckIcon from "@/assets/svg/check.svg";
 import { SignupFormValues } from "@/types/form/signup";
+import { useAtomValue } from "jotai";
+import { $checkEmail, $checkNickname } from "@/store/auth";
 
 interface Props {
   defaultValues: SignupFormValues;
@@ -23,6 +25,7 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
   const {
     register,
     watch,
+    setError,
     handleSubmit,
     formState: { errors, isValid },
   } = useForm<SignupFormValues>({
@@ -30,7 +33,7 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
     defaultValues,
   });
 
-  const { password, privacy, marketing } = watch();
+  const { password, passwordConfirm, privacy, marketing, email, nickname } = watch();
 
   const emailRegister = register("email", {
     required: true,
@@ -65,6 +68,47 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
     },
   });
 
+  const { data: checkEmailReponse, mutate: checkEmail } = useAtomValue($checkEmail);
+  const { data: checkNicknameReponse, mutate: checkNickname } = useAtomValue($checkNickname);
+
+  const [isExistEmail, setIsExistEmail] = useState<boolean | null>(null);
+  const [isExistNickname, setIsExistNickname] = useState<boolean | null>(null);
+  const isDisabledSignupButton = !isValid || isExistEmail !== false || isExistNickname !== false;
+
+  const handleCheckEmail = () => {
+    checkEmail(email);
+  };
+
+  const handleCheckNickname = () => {
+    checkNickname(nickname);
+  };
+
+  useEffect(() => {
+    if (checkEmailReponse) {
+      setIsExistEmail(checkEmailReponse.isExist);
+    }
+    if (checkEmailReponse?.isExist) {
+      setError("email", { message: "이미 사용 중인 이메일입니다." });
+    }
+  }, [checkEmailReponse, setIsExistEmail, setError]);
+
+  useEffect(() => {
+    if (checkNicknameReponse) {
+      setIsExistNickname(checkNicknameReponse.isExist);
+    }
+    if (checkNicknameReponse?.isExist) {
+      setError("nickname", { message: "이미 사용 중인 닉네임입니다." });
+    }
+  }, [checkNicknameReponse, setIsExistNickname, setError]);
+
+  useEffect(() => {
+    setIsExistEmail(null);
+  }, [email, setIsExistEmail]);
+
+  useEffect(() => {
+    setIsExistNickname(null);
+  }, [nickname, setIsExistNickname]);
+
   return (
     <Fragment>
       <Header hasPreviousPage>회원가입</Header>
@@ -73,10 +117,17 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
           <div className={styles.labelContainer}>
             <Label htmlFor="email">이메일</Label>
             {errors.email && <p className={styles.errorMessage}>{errors.email.message}</p>}
+            {isExistEmail === false && (
+              <p className={styles.successMessage}>사용 가능한 이메일입니다.</p>
+            )}
           </div>
           <div className={styles.emailContainer}>
             <Input {...emailRegister} id="email" type="email" placeholder="이메일을 입력해주세요" />
-            <button type="button" className={styles.checkDuplicateButton}>
+            <button
+              type="button"
+              className={styles.checkDuplicateButton}
+              onClick={handleCheckEmail}
+            >
               중복확인
             </button>
           </div>
@@ -98,6 +149,9 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
             {errors.passwordConfirm && (
               <p className={styles.errorMessage}>{errors.passwordConfirm.message}</p>
             )}
+            {passwordConfirm && !errors.passwordConfirm && (
+              <p className={styles.successMessage}>비밀번호가 일치합니다.</p>
+            )}
           </div>
           <Input
             {...passwordConfirmRegister}
@@ -110,6 +164,9 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
           <div className={styles.labelContainer}>
             <Label htmlFor="nickname">닉네임</Label>
             {errors.nickname && <p className={styles.errorMessage}>{errors.nickname.message}</p>}
+            {isExistNickname === false && (
+              <p className={styles.successMessage}>사용 가능한 닉네임입니다.</p>
+            )}
           </div>
           <div className={styles.nicknameContainer}>
             <Input
@@ -118,7 +175,11 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
               type="text"
               placeholder="닉네임 2~6자를 입력해주세요"
             />
-            <button type="button" className={styles.checkDuplicateButton}>
+            <button
+              type="button"
+              className={styles.checkDuplicateButton}
+              onClick={handleCheckNickname}
+            >
               중복확인
             </button>
           </div>
@@ -158,7 +219,7 @@ const SignupForm = ({ defaultValues, onSubmit }: Props) => {
           <Button
             color="primary.100"
             applyColorTo="background"
-            disabled={!isValid}
+            disabled={isDisabledSignupButton}
             className={styles.signupButton}
           >
             회원가입 하기
@@ -222,6 +283,11 @@ const styles = {
   errorMessage: css({
     fontSize: "1.2rem",
     color: "red.100",
+    marginLeft: "0.4rem",
+  }),
+  successMessage: css({
+    fontSize: "1.2rem",
+    color: "green.100",
     marginLeft: "0.4rem",
   }),
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,14 +7,11 @@ import { ColorToken } from "@styled-system/tokens";
 
 import { Filter } from "@/types/utils.ts";
 
-type ButtonColor = Filter<
-  ColorToken,
-  "primary.100" | "primary.45" | "secondary.100" | "yellow.100"
->;
+type ButtonColor = Filter<ColorToken, "primary.100" | "primary.45" | "secondary.100">;
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
-  color: ButtonColor;
-  applyColorTo: "background" | "outline";
+  color?: ButtonColor;
+  applyColorTo?: "background" | "outline";
   size?: "full";
 }
 
@@ -23,8 +20,8 @@ const Button = ({
   onClick,
   className,
   disabled = false,
-  color,
-  applyColorTo,
+  color = "primary.100",
+  applyColorTo = "background",
   size = "full",
 }: Props) => {
   const buttonStyle = classNames(

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -32,8 +32,7 @@ const styles = {
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: "black",
-    opacity: 0.7,
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
@@ -43,7 +42,6 @@ const styles = {
   container: css({
     width: "31.2rem",
     padding: "1.6rem",
-    opacity: 1,
     paddingBottom: "2.4rem",
     borderRadius: "0.8rem",
     backgroundColor: "back",

--- a/src/components/shared/WelcomModal.tsx
+++ b/src/components/shared/WelcomModal.tsx
@@ -6,12 +6,13 @@ import useRouter from "@/routes/useRouter";
 import Modal from "@/components/common/modal/Modal";
 import Button from "@/components/common/Button";
 import DumplingIcon from "@/assets/svg/dumpling.svg";
+import { IngredientName } from "@/types/ingredient";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   nickname: string;
-  uniqueIngredient: string;
+  uniqueIngredient: IngredientName;
 }
 
 const WelcomModal = ({ isOpen, onClose, nickname, uniqueIngredient }: Props) => {
@@ -87,7 +88,7 @@ const styles = {
   content: css({
     fontSize: "1.4rem",
     textAlign: "center",
-    paddingX: "3.6rem",
+    whiteSpace: "pre-line",
   }),
   ingredientImage: css({
     display: "flex",

--- a/src/constants/ingredient.ts
+++ b/src/constants/ingredient.ts
@@ -1,0 +1,14 @@
+export const INGREDIENTS = {
+  RICE_CAKE: "희망떡",
+  EGG: "사랑계란",
+  SEAWEED: "해피김",
+  GREEN_ONION: "행운파",
+  BEEF: "튼튼고기",
+  MUSHROOM: "용기버섯",
+  TOFU: "스마일두부",
+  FISH_CAKE: "응원어묵",
+  CANDY: "일등사탕",
+  DUMPLING: "당첨만두",
+  TAIYAKI: "금붕어빵",
+  GARLIC: "성공마늘",
+} as const;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,9 +18,7 @@ const LoginPage = () => {
             이메일로 로그인
           </Button>
         </Link>
-        <Button color="yellow.100" applyColorTo="background" className={styles.kakaoLoginButton}>
-          카카오로 로그인
-        </Button>
+        <Button className={styles.kakaoLoginButton}>카카오로 로그인</Button>
         <Link to="/signup" className={styles.signupLink}>
           회원가입 하러가기&gt;
         </Link>
@@ -45,6 +43,7 @@ const styles = {
   }),
   kakaoLoginButton: css({
     marginBottom: "8rem",
+    backgroundColor: "#FEE500",
   }),
   signupLink: css({
     display: "block",

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,12 +1,16 @@
-import { Fragment } from "react";
+import { Fragment, useEffect } from "react";
 import { useOverlay } from "@toss/use-overlay";
 
 import Header from "@/components/common/Header";
 import SignupForm from "@/components/Signup/SignupForm";
 import WelcomModal from "@/components/shared/WelcomModal";
 import { SignupFormValues } from "@/types/form/signup";
+import { useAtomValue } from "jotai";
+import { $signup } from "@/store/auth";
+import { INGREDIENTS } from "@/constants/ingredient";
 
 const SignupPage = () => {
+  const welcomModal = useOverlay();
   const defaultValues: SignupFormValues = {
     email: "",
     password: "",
@@ -16,14 +20,33 @@ const SignupPage = () => {
     marketing: false,
   };
 
-  const welcomModal = useOverlay();
+  const { mutate: signup, data: signupResponse, error: signupError } = useAtomValue($signup);
 
-  const handleSubmit = (values: SignupFormValues) => {
-    console.log(values);
-    welcomModal.open(({ isOpen, close }) => (
-      <WelcomModal isOpen={isOpen} onClose={close} nickname="민수르" uniqueIngredient="성공마늘" />
-    ));
+  const handleSubmit = async ({ email, password, nickname, marketing }: SignupFormValues) => {
+    signup({
+      email,
+      password,
+      nickname,
+      acceptsMarketing: marketing,
+    });
   };
+
+  useEffect(() => {
+    if (signupResponse) {
+      welcomModal.open(({ isOpen, close }) => (
+        <WelcomModal
+          isOpen={isOpen}
+          onClose={close}
+          nickname={signupResponse.nickname}
+          uniqueIngredient={INGREDIENTS[signupResponse.primaryIngredient]}
+        />
+      ));
+    }
+    if (signupError) {
+      // TODO: 예외 처리
+      console.log("signup error");
+    }
+  }, [signupResponse, signupError]);
 
   return (
     <Fragment>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,8 +1,10 @@
 import { Fragment } from "react";
+import { useOverlay } from "@toss/use-overlay";
 
 import Header from "@/components/common/Header";
-import { SignupFormValues } from "@/types/form/signup";
 import SignupForm from "@/components/Signup/SignupForm";
+import WelcomModal from "@/components/shared/WelcomModal";
+import { SignupFormValues } from "@/types/form/signup";
 
 const SignupPage = () => {
   const defaultValues: SignupFormValues = {
@@ -14,8 +16,13 @@ const SignupPage = () => {
     marketing: false,
   };
 
+  const welcomModal = useOverlay();
+
   const handleSubmit = (values: SignupFormValues) => {
     console.log(values);
+    welcomModal.open(({ isOpen, close }) => (
+      <WelcomModal isOpen={isOpen} onClose={close} nickname="민수르" uniqueIngredient="성공마늘" />
+    ));
   };
 
   return (

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -4,16 +4,15 @@ import { CheckEmailNicknameResponse, SignupRequest, SignupResponse } from "@/typ
 
 export const $checkEmail = atomWithMutation(() => ({
   mutationKey: ["checkEmail"],
-  mutationFn: async (email: string): Promise<CheckEmailNicknameResponse> => checkEmail(email),
+  mutationFn: (email: string): Promise<CheckEmailNicknameResponse> => checkEmail(email),
 }));
 
 export const $checkNickname = atomWithMutation(() => ({
   mutationKey: ["checkNickname"],
-  mutationFn: async (nickname: string): Promise<CheckEmailNicknameResponse> =>
-    checkNickname(nickname),
+  mutationFn: (nickname: string): Promise<CheckEmailNicknameResponse> => checkNickname(nickname),
 }));
 
 export const $signup = atomWithMutation(() => ({
   mutationKey: ["signup"],
-  mutationFn: async (body: SignupRequest): Promise<SignupResponse> => postSignup(body),
+  mutationFn: (body: SignupRequest): Promise<SignupResponse> => postSignup(body),
 }));

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,14 @@
+import { atomWithMutation } from "jotai-tanstack-query";
+import { checkEmail, checkNickname } from "@/apis/auth";
+import { CheckEmailNicknameResponse } from "@/types/auth";
+
+export const $checkEmail = atomWithMutation(() => ({
+  mutationKey: ["checkEmail"],
+  mutationFn: async (email: string): Promise<CheckEmailNicknameResponse> => checkEmail(email),
+}));
+
+export const $checkNickname = atomWithMutation(() => ({
+  mutationKey: ["checkNickname"],
+  mutationFn: async (nickname: string): Promise<CheckEmailNicknameResponse> =>
+    checkNickname(nickname),
+}));

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,6 +1,6 @@
 import { atomWithMutation } from "jotai-tanstack-query";
-import { checkEmail, checkNickname } from "@/apis/auth";
-import { CheckEmailNicknameResponse } from "@/types/auth";
+import { checkEmail, checkNickname, postSignup } from "@/apis/auth";
+import { CheckEmailNicknameResponse, SignupRequest, SignupResponse } from "@/types/auth";
 
 export const $checkEmail = atomWithMutation(() => ({
   mutationKey: ["checkEmail"],
@@ -11,4 +11,9 @@ export const $checkNickname = atomWithMutation(() => ({
   mutationKey: ["checkNickname"],
   mutationFn: async (nickname: string): Promise<CheckEmailNicknameResponse> =>
     checkNickname(nickname),
+}));
+
+export const $signup = atomWithMutation(() => ({
+  mutationKey: ["signup"],
+  mutationFn: async (body: SignupRequest): Promise<SignupResponse> => postSignup(body),
 }));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,5 @@
+import { IngredientKey } from "./ingredient";
+
 export interface CheckEmailNicknameResponse {
   isExist: boolean;
 }
@@ -12,5 +14,5 @@ export interface SignupRequest {
 export interface SignupResponse {
   id: number;
   nickname: string;
-  primaryIngredient: string;
+  primaryIngredient: IngredientKey;
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,16 @@
 export interface CheckEmailNicknameResponse {
   isExist: boolean;
 }
+
+export interface SignupRequest {
+  email: string;
+  password: string;
+  nickname: string;
+  acceptsMarketing: boolean;
+}
+
+export interface SignupResponse {
+  id: number;
+  nickname: string;
+  primaryIngredient: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,3 @@
+export interface CheckEmailNicknameResponse {
+  isExist: boolean;
+}

--- a/src/types/ingredient.ts
+++ b/src/types/ingredient.ts
@@ -1,0 +1,5 @@
+import { INGREDIENTS } from "@/constants/ingredient";
+import { KeyOf, ValueOf } from "./utils";
+
+export type IngredientKey = KeyOf<typeof INGREDIENTS>;
+export type IngredientName = ValueOf<typeof INGREDIENTS>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,1 +1,5 @@
 export type Filter<TOrigin, TAllowed> = TOrigin extends TAllowed ? TOrigin : never;
+export type KeyOf<T> = keyof T;
+export type ValueOf<T> = T extends Array<unknown> | Readonly<Array<unknown>>
+  ? T[number]
+  : T[keyof T];


### PR DESCRIPTION
## 📝 작업 내용

- 회원가입, 중복확인 API 연동
  - 관련 api 추가
  - jotai atom 추가
- 이메일 및 닉네임 중복확인, 비밀번호 확인 성공메세지 작업
- 회원가입 성공시 WelcomeModal 노출

close #34
