### PR TITLE
[#42] Chore: vercel rewrites 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 📝 작업 내용

현재 vercel로 배포된 페이지는 path를 직접 변경할 경우, 경로를 찾지 못하고 404 에러를 던집니다.
이에 대비하기 위해 vercel 설정에 rewrites를 추가하여 path를 직접 변경하더라도 index.html을 응답하도록 하겠습니다.

`vercel.json`에 rewrites를 설정해주었습니다.


close #42 
