### PR TITLE
[#82] Feat: 유저 탈퇴하기 api와 atom 구현 및 적용

### DIFF
--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -60,7 +60,7 @@ const refreshAccessToken = async (token: string) => {
 
 const handleResponse = <Response>(response: KyResponse) => {
   if (response.status === 204 || response.headers.get("content-length") === "0") {
-    return {} as Response;
+    return Promise.resolve({} as Response);
   }
 
   return response.json<Response>();

--- a/src/apis/core.ts
+++ b/src/apis/core.ts
@@ -58,7 +58,13 @@ const refreshAccessToken = async (token: string) => {
   }
 };
 
-const handleResponse = <Response>(response: KyResponse) => response.json<Response>();
+const handleResponse = <Response>(response: KyResponse) => {
+  if (response.status === 204 || response.headers.get("content-length") === "0") {
+    return {} as Response;
+  }
+
+  return response.json<Response>();
+};
 
 export default {
   get: <Response>(url: Input) => kyInstance.get(url).then(handleResponse<Response>),
@@ -68,6 +74,8 @@ export default {
     kyInstance.patch(url, { json }).then(handleResponse<Response>),
   put: <Response>(url: Input, json: unknown) =>
     kyInstance.patch(url, { json }).then(handleResponse<Response>),
-  delete: <Response>(url: Input, json: unknown) =>
-    kyInstance.patch(url, { json }).then(handleResponse<Response>),
+  delete: <Response>(url: Input, json?: unknown) => {
+    const options = json ? { json } : {};
+    return kyInstance.delete(url, options).then(handleResponse<Response>);
+  },
 };

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -8,3 +8,5 @@ export const getUserDetails = (id: number) => http.get<UserDetailsResponse>(`api
 
 export const getSearchedUsers = (nickname: string) =>
   http.get<SearchedUserResponse>(`api/v1/user/all?nickname=${nickname}`);
+
+export const deleteLoggedInUser = () => http.delete("api/v1/user/me");

--- a/src/components/shared/WelcomeModal.tsx
+++ b/src/components/shared/WelcomeModal.tsx
@@ -53,7 +53,7 @@ const WelcomeModal = ({ isOpen, onClose, nickname, uniqueIngredientKey }: Props)
     if (step === modalContents.length - 1) {
       onClose();
       setStep(0);
-      router.push("/tteokguks");
+      router.push("/");
     }
   };
 

--- a/src/components/shared/WelcomeModal.tsx
+++ b/src/components/shared/WelcomeModal.tsx
@@ -53,7 +53,7 @@ const WelcomeModal = ({ isOpen, onClose, nickname, uniqueIngredientKey }: Props)
     if (step === modalContents.length - 1) {
       onClose();
       setStep(0);
-      router.push("/");
+      router.push("/tteokguks");
     }
   };
 

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -8,7 +8,7 @@ type AlertParams = Omit<DialogModalContextProps, "isOpen" | "type" | "cancelButt
 type ConfirmParams = Omit<DialogModalContextProps, "isOpen" | "type">;
 type OpenDialogModalParams = Omit<DialogModalContextProps, "isOpen">;
 
-export const useDailog = () => {
+export const useDialog = () => {
   const [, setDialogModalProps] = useContext(DialogModalContext);
 
   const handleOpenDialogModal = (params: OpenDialogModalParams) =>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -2,10 +2,14 @@ import { Fragment } from "react";
 
 import { useAtomValue } from "jotai";
 
+import { useDialog } from "@/hooks/useDialog";
+
 import { css } from "@styled-system/css";
 
+import { removeLocalStorage } from "@/utils/localStorage";
+
 import { Link } from "@/routes/Link";
-import { $getMyDetails } from "@/store/user";
+import { $deleteLoggedInUser, $getMyDetails } from "@/store/user";
 import { INGREDIENT_ICON_BY_KEY } from "@/constants/ingredient";
 import Header from "@/components/common/Header";
 import IconButton from "@/components/common/IconButton";
@@ -13,11 +17,61 @@ import TteokgukList from "@/components/common/TteokgukList";
 import IngredientList from "@/components/Mypage/IngredientList";
 import VisitIcon from "@/assets/svg/visit.svg";
 import ActivityIcon from "@/assets/svg/activity.svg";
+import useRouter from "@/routes/useRouter";
 
 const MyPage = () => {
+  const router = useRouter();
   const { data: myDetails } = useAtomValue($getMyDetails);
+  const { mutate: deleteLoggedInUser } = useAtomValue($deleteLoggedInUser);
+  const { confirm, alert } = useDialog();
   const { nickname, primaryIngredient, tteokguks, items: ingredients } = myDetails;
   const IngredientIcon = INGREDIENT_ICON_BY_KEY[40][primaryIngredient];
+
+  const handleClickWithdrawalButton = async () => {
+    const isConfirmedWithdrawal = await confirm({
+      title: <span className={styles.confirmTitle}>정말 탈퇴하시겠어요?</span>,
+      description: (
+        <div>
+          <div className={styles.confirmContent}>
+            <span className={styles.block}>계정을 삭제하면 복구할 수 없어요.</span>
+            다른 사람들과 함께 더 많은 소원을 이뤄보세요🥺
+          </div>
+          <div className={styles.confirmDescription}>
+            <span className={styles.block}>*계정을 삭제해도 작성하신 소원은 남아있어요.</span>
+            <span className={styles.block}>남아있는 소원을 지우시고 싶으시다면</span>
+            소원 떡국 하단의 삭제하기를 눌러주세요.
+          </div>
+        </div>
+      ),
+      confirmButton: { text: "탈퇴", color: "primary.45", applyColorTo: "outline" },
+      cancelButton: { text: "취소", color: "primary.100", applyColorTo: "background" },
+    });
+
+    if (!isConfirmedWithdrawal) return;
+
+    deleteLoggedInUser(undefined, {
+      onSuccess: () => {
+        removeLocalStorage("accessToken");
+        removeLocalStorage("refreshToken");
+
+        alert({
+          title: <div className={styles.alertTitle}>탈퇴가 완료되었어요</div>,
+          description: (
+            <div className={styles.alertContent}>
+              <span className={styles.block}>새해에 더 이루고싶은 소원이 생각나시면</span>
+              다시 한 번 떡국을 부탁해를 들려주세요!🥺
+            </div>
+          ),
+          confirmButton: {
+            text: "첫 화면으로 이동",
+            color: "primary.100",
+            applyColorTo: "background",
+            onClick: () => router.push("/"),
+          },
+        });
+      },
+    });
+  };
 
   return (
     <Fragment>
@@ -69,7 +123,7 @@ const MyPage = () => {
         </div>
         <div className={styles.accountContainer}>
           <button>로그아웃</button>
-          <button>탈퇴하기</button>
+          <button onClick={handleClickWithdrawalButton}>탈퇴하기</button>
         </div>
       </div>
     </Fragment>
@@ -132,5 +186,36 @@ const styles = {
   }),
   full: css({
     width: "100%",
+  }),
+  block: css({
+    display: "block",
+  }),
+  confirmTitle: css({
+    fontSize: "1.6rem",
+  }),
+  confirmContent: css({
+    display: "flex",
+    flexFlow: "row wrap",
+    justifyContent: "center",
+    fontSize: "1.4rem",
+    marginY: "1.6rem",
+  }),
+  confirmDescription: css({
+    display: "flex",
+    flexFlow: "row wrap",
+    justifyContent: "center",
+    fontSize: "1.2rem",
+    color: "gray.50",
+    marginY: "1.6rem",
+  }),
+  alertTitle: css({
+    fontSize: "1.6rem",
+  }),
+  alertContent: css({
+    display: "flex",
+    flexFlow: "row wrap",
+    justifyContent: "center",
+    fontSize: "1.4rem",
+    marginY: "1.6rem",
   }),
 };

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -3,6 +3,8 @@ import { Fragment } from "react";
 import { useOverlay } from "@toss/use-overlay";
 import { useAtomValue } from "jotai";
 
+import { setLocalStorage } from "@/utils/localStorage";
+
 import { SignupFormValues } from "@/types/form";
 
 import Header from "@/components/common/Header";
@@ -32,7 +34,10 @@ const SignupPage = () => {
         acceptsMarketing: marketing,
       },
       {
-        onSuccess: ({ nickname, primaryIngredient }) => {
+        onSuccess: ({ nickname, primaryIngredient, accessToken, refreshToken }) => {
+          setLocalStorage("accessToken", accessToken);
+          setLocalStorage("refreshToken", refreshToken);
+
           welcomeModal.open(({ isOpen, close }) => (
             <WelcomeModal
               isOpen={isOpen}

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,8 +1,8 @@
-import { atomWithQuery, atomWithSuspenseQuery } from "jotai-tanstack-query";
+import { atomWithMutation, atomWithQuery, atomWithSuspenseQuery } from "jotai-tanstack-query";
 import { atom } from "jotai";
 import { atomFamily } from "jotai/utils";
 
-import { getMyDetails, getSearchedUsers, getUserDetails } from "@/apis/user";
+import { deleteLoggedInUser, getMyDetails, getSearchedUsers, getUserDetails } from "@/apis/user";
 
 import { atomFamilyWithSuspenseQuery } from "@/utils/jotai";
 
@@ -25,3 +25,9 @@ export const $getSearchedUsers = atomFamily(() =>
     enabled: !!get($nickname),
   })),
 );
+
+export const $deleteLoggedInUser = atomWithMutation(() => {
+  return {
+    mutationFn: deleteLoggedInUser,
+  };
+});

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -15,6 +15,8 @@ export interface SignupResponse {
   id: number;
   nickname: string;
   primaryIngredient: IngredientKey;
+  accessToken: string;
+  refreshToken: string;
 }
 
 export interface LoginRequest {

--- a/src/types/dialog.ts
+++ b/src/types/dialog.ts
@@ -5,7 +5,7 @@ import { ButtonColor } from "@/components/common/Button";
 export interface DialogModalContextProps {
   isOpen: boolean;
   type: "alert" | "confirm";
-  title?: string;
+  title?: ReactNode;
   description: ReactNode;
   confirmButton: {
     text: string;

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -21,3 +21,11 @@ export const setLocalStorage = <T>(key: string, value: T) => {
     console.error(`Error serializing value for localStorage item with key "${key}":`, error);
   }
 };
+
+export const removeLocalStorage = (key: string) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    console.error(`Failed to remove item from localStorage with key "${key}". Error: ${error}`);
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용

1. delete method가 body를 필수적으로 받도록 `apis/core.ts`에서 설정하고 있더라구요. 이거 때문에 요청이 막혔습니다ㅠ
2. 현재 탈퇴하기는 삭제시 response를 아무것도 내려주고 있지 않은데, `handleResponse`에서 `.json()` 해주고 있어서 문제가 있었습니다.

위 두 문제를 해결하기 위해 `apis/core.ts`를 수정했는데, 혹시 문제가 있을 것 같다면 알려주세요! 91820a8

그 외에는 api, atom을 구현하고 탈퇴 성공시에 alert, removeLocalStorage 정도가 추가되었습니다.

close #82
