### PR TITLE
[#112] Modify: 로그인, 로그아웃시 떡국 리스트 invalidate

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "react";
 
 import { useAtomValue } from "jotai";
+import { queryClientAtom } from "jotai-tanstack-query";
 
 import { useDialog } from "@/hooks/useDialog";
 
@@ -27,6 +28,7 @@ const MyPage = () => {
   const { data: myDetails, isPending, isError, refetch } = useAtomValue($getMyDetails);
   const { mutate: deleteLoggedInUser } = useAtomValue($deleteLoggedInUser);
   const { refetch: refetchRandomUserDetails } = useAtomValue($getRandomUserDetails);
+  const { invalidateQueries } = useAtomValue(queryClientAtom);
   const { confirm } = useDialog();
 
   if (isPending) {
@@ -83,6 +85,7 @@ const MyPage = () => {
       removeLocalStorage("refreshToken");
 
       router.push("/");
+      invalidateQueries({ queryKey: ["newTteokguks"] });
     }
   };
 

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,4 +1,4 @@
-import { atomWithMutation } from "jotai-tanstack-query";
+import { atomWithMutation, queryClientAtom } from "jotai-tanstack-query";
 
 import {
   checkEmail,
@@ -35,17 +35,23 @@ export const $signup = atomWithMutation(() => ({
   mutationFn: (body: SignupRequest): Promise<SignupResponse> => postSignup(body),
 }));
 
-export const $login = atomWithMutation(() => ({
+export const $login = atomWithMutation((get) => ({
   mutationFn: (body: LoginRequest): Promise<LoginResponse> => postLogin(body),
+  onSuccess: () => {
+    get(queryClientAtom).invalidateQueries({ queryKey: ["newTteokguks"] });
+  },
 }));
 
 export const $postKakaoToken = atomWithMutation(() => ({
   mutationFn: (code: string): Promise<PostKakaoTokenReponse> => postKakaoToken(code),
 }));
 
-export const $postKakaoLogin = atomWithMutation(() => ({
+export const $postKakaoLogin = atomWithMutation((get) => ({
   mutationFn: (body: PostKakaoLoginRequest): Promise<PostKakaoLoginResponse> =>
     postKakaoLogin(body),
+  onSuccess: () => {
+    get(queryClientAtom).invalidateQueries({ queryKey: ["newTteokguks"] });
+  },
 }));
 
 export const $postKakaoUserSignup = atomWithMutation(() => ({


### PR DESCRIPTION
## 📝 작업 내용

로그인, 로그아웃시 떡국 리스트 invalidate
로그인, 로그아웃시 떡국 리스트를 새로 받아오지 않아 응원 요청 뱃지가 남아있거나 생기지 않은 이슈가 있었습니다.
이를 해결하기 위해 따로 invalidate 처리해주었습니다.

close #112
