### PR TITLE
[#117] Fix: 재료 추가 모달 이슈 수정

### DIFF
--- a/src/components/TteokgukCookingPage/Ingredient.tsx
+++ b/src/components/TteokgukCookingPage/Ingredient.tsx
@@ -24,9 +24,7 @@ const Ingredient = ({
   isDisabled,
   handleClickIngredient,
 }: Props) => {
-  const isInfiniteQuantity = stockQuantity >= MAX_INGREDIENT_QUANTITY;
-  const remainQuantity = isSelected ? stockQuantity - 1 : stockQuantity;
-  const quantity = isInfiniteQuantity ? INFINITY : remainQuantity;
+  const quantity = stockQuantity >= MAX_INGREDIENT_QUANTITY ? INFINITY : stockQuantity;
 
   const IngredientIcon = INGREDIENT_ICON_BY_KEY[isDisabled ? "disabled" : 40][ingredientKey];
 

--- a/src/components/common/ReceivedIngredientsList.tsx
+++ b/src/components/common/ReceivedIngredientsList.tsx
@@ -23,40 +23,42 @@ const ReceivedIngredientsList = ({ receivedIngredientList }: Props) => {
 
   return (
     <ul className={styles.list}>
-      {receivedIngredientList.map(({ id, senderId, nickname, ingredient, message, access }) => {
-        const IngredientIcon = INGREDIENT_ICON_BY_KEY[40][ingredient];
-        const ANONIMOUS_NICKNAME = `익명의 ${INGREDIENT_NAME_BY_KEY[ingredient]}`;
+      {receivedIngredientList.map(
+        ({ id, senderId, nickname, ingredient, message, access, supportedTteokgukId }) => {
+          const IngredientIcon = INGREDIENT_ICON_BY_KEY[40][ingredient];
+          const ANONIMOUS_NICKNAME = `익명의 ${INGREDIENT_NAME_BY_KEY[ingredient]}`;
 
-        return (
-          <li key={id} className={styles.listItem}>
-            <div className={styles.ingredientContainer}>
-              <div className={styles.ingredientContent}>
-                <div className={styles.iconContainer}>
-                  <IngredientIcon aria-label={INGREDIENT_NAME_BY_KEY[ingredient]} />
+          return (
+            <li key={id} className={styles.listItem}>
+              <div className={styles.ingredientContainer}>
+                <div className={styles.ingredientContent}>
+                  <div className={styles.iconContainer}>
+                    <IngredientIcon aria-label={INGREDIENT_NAME_BY_KEY[ingredient]} />
+                  </div>
+                  <div>
+                    <div className={styles.title}>@{access ? nickname : ANONIMOUS_NICKNAME}</div>
+                    <div>응원의 {INGREDIENT_NAME_BY_KEY[ingredient]}(이/가) 도착했어요!</div>
+                  </div>
                 </div>
-                <div>
-                  <div className={styles.title}>@{access ? nickname : ANONIMOUS_NICKNAME}</div>
-                  <div>응원의 {INGREDIENT_NAME_BY_KEY[ingredient]}(이/가) 도착했어요!</div>
+                <div className={styles.buttonContainer}>
+                  <Link to={`/tteokguks/${supportedTteokgukId}`} className={styles.button}>
+                    <button>내 떡국 보러가기</button>
+                  </Link>
+                  <Link to={`/users/${senderId}`} className={styles.button}>
+                    <button>방문하기</button>
+                  </Link>
                 </div>
               </div>
-              <div className={styles.buttonContainer}>
-                <Link to={`/tteokguks/${id}`} className={styles.button}>
-                  <button>내 떡국 보러가기</button>
-                </Link>
-                <Link to={`/users/${senderId}`} className={styles.button}>
-                  <button>방문하기</button>
-                </Link>
+              <div className={styles.message}>
+                <div className={styles.messageContent}>{message}</div>
+                <button onClick={handleClickMoreButton(message)} className={styles.moreButton}>
+                  더보기
+                </button>
               </div>
-            </div>
-            <div className={styles.message}>
-              <div className={styles.messageContent}>{message}</div>
-              <button onClick={handleClickMoreButton(message)} className={styles.moreButton}>
-                더보기
-              </button>
-            </div>
-          </li>
-        );
-      })}
+            </li>
+          );
+        },
+      )}
     </ul>
   );
 };

--- a/src/components/shared/CreateCheerMessageModal.tsx
+++ b/src/components/shared/CreateCheerMessageModal.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FormEvent, useState } from "react";
 
 import { useOverlay } from "@toss/use-overlay";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
 import { css } from "@styled-system/css";
 
@@ -11,7 +11,7 @@ import Button from "@/components/common/Button";
 import Modal from "@/components/common/modal/Modal";
 import CheckIcon from "@/assets/svg/check.svg";
 import NoCheckIcon from "@/assets/svg/no-check.svg";
-import { $postIngredientToOthersTteokguk, $selectedIngredient } from "@/store/ingredient";
+import { $postIngredientToOthersTteokguk, $updateSelectedIngredient } from "@/store/ingredient";
 
 interface Props {
   isOpen: boolean;
@@ -24,7 +24,7 @@ const MAX_CHARACTER = 100;
 const CreateCheerMessageModal = ({ isOpen, onClose, tteokgukId }: Props) => {
   const cheerSuccessOverlay = useOverlay();
   const { mutate: postIngredient, isPending } = useAtomValue($postIngredientToOthersTteokguk);
-  const selectedIngredient = useAtomValue($selectedIngredient);
+  const [selectedIngredient, updateSelectedIngredient] = useAtom($updateSelectedIngredient);
   const [message, setMessage] = useState("");
   const [isAnonymous, setIsAnonymous] = useState(false);
 
@@ -68,10 +68,15 @@ const CreateCheerMessageModal = ({ isOpen, onClose, tteokgukId }: Props) => {
     );
   };
 
+  const handleClickClose = () => {
+    updateSelectedIngredient(null);
+    onClose();
+  };
+
   return (
     isOpen && (
       <Modal className={styles.container}>
-        <Modal.Header hasCloseButton onClose={onClose}>
+        <Modal.Header hasCloseButton onClose={handleClickClose}>
           응원 메시지 남기기
         </Modal.Header>
         <Modal.Body className={styles.bodyContainer}>

--- a/src/components/shared/SendIngredientToOthersTteokgukModal.tsx
+++ b/src/components/shared/SendIngredientToOthersTteokgukModal.tsx
@@ -35,8 +35,6 @@ const SendIngredientsToOthersTteokgukModal = ({
   const { itemResponses: ingredientsStocks } = myDetails;
 
   const handleClickIngredient = (ingredientKey: IngredientKey) => () => {
-    if (!requiredIngredients.includes(ingredientKey)) return;
-
     updateSelectedIngredient(ingredientKey);
   };
 

--- a/src/components/shared/SendIngredientToOthersTteokgukModal.tsx
+++ b/src/components/shared/SendIngredientToOthersTteokgukModal.tsx
@@ -41,7 +41,6 @@ const SendIngredientsToOthersTteokgukModal = ({
   };
 
   const handleClickNextButton = () => {
-    updateSelectedIngredient([]);
     if (!selectedIngredient) return;
 
     createCheerMessageModalOverlay.open(({ isOpen, close: handleCloseCheerMessageModal }) => (
@@ -56,10 +55,15 @@ const SendIngredientsToOthersTteokgukModal = ({
     ));
   };
 
+  const handleClickClose = () => {
+    updateSelectedIngredient(null);
+    onClose();
+  };
+
   return (
     isOpen && (
       <Modal className={styles.container}>
-        <Modal.Header onClose={onClose} hasCloseButton className={styles.title}>
+        <Modal.Header onClose={handleClickClose} hasCloseButton className={styles.title}>
           떡국 재료 보내기
         </Modal.Header>
         <Modal.Body className={styles.contentContainer}>

--- a/src/pages/TteokgukPage.tsx
+++ b/src/pages/TteokgukPage.tsx
@@ -187,15 +187,21 @@ const TteokgukPage = () => {
             </Button>
           </Link>
         )}
-        {isLoggedIn && (
+        {!isMyTteokguk && !completion && (
           <Button
             onClick={handleClickAddIngredientButton}
             color="primary.45"
             applyColorTo="outline"
           >
-            {loggedInUserDetails?.id === memberId ? "떡국 재료 추가하기" : "떡국 재료 보내기"}
+            떡국 재료 보내기
           </Button>
         )}
+        {isMyTteokguk && !completion && (
+          <Button color="primary.45" applyColorTo="outline">
+            떡국 재료 추가하기
+          </Button>
+        )}
+
         {isMyTteokguk && (
           <div className={styles.wishDeleteButton}>
             <button onClick={handleClickDeleteTteokgukButton}>소원 삭제하기</button>

--- a/src/pages/TteokgukPage.tsx
+++ b/src/pages/TteokgukPage.tsx
@@ -187,6 +187,7 @@ const TteokgukPage = () => {
             </Button>
           </Link>
         )}
+
         {!isMyTteokguk && !completion && (
           <Button
             onClick={handleClickAddIngredientButton}
@@ -197,9 +198,20 @@ const TteokgukPage = () => {
           </Button>
         )}
         {isMyTteokguk && !completion && (
-          <Button color="primary.45" applyColorTo="outline">
+          <Button
+            onClick={handleClickAddIngredientButton}
+            color="primary.45"
+            applyColorTo="outline"
+          >
             떡국 재료 추가하기
           </Button>
+        )}
+        {isMyTteokguk && completion && (
+          <Link to="/tteokguk/create">
+            <Button color="primary.45" applyColorTo="outline">
+              다른 떡국 만들기
+            </Button>
+          </Link>
         )}
 
         {isMyTteokguk && (

--- a/src/store/ingredient.ts
+++ b/src/store/ingredient.ts
@@ -42,8 +42,13 @@ export const $updateSelectedIngredients = atom(
 export const $selectedIngredient = atom<IngredientKey | null>(null);
 export const $updateSelectedIngredient = atom(
   (get) => get($selectedIngredient),
-  (_get, set, selectedIngredient: IngredientKey | null) => {
+  (get, set, selectedIngredient: IngredientKey | null) => {
     if (selectedIngredient === null) {
+      set($selectedIngredient, null);
+      return;
+    }
+
+    if (get($selectedIngredient) === selectedIngredient) {
       set($selectedIngredient, null);
       return;
     }

--- a/src/store/ingredient.ts
+++ b/src/store/ingredient.ts
@@ -43,12 +43,7 @@ export const $selectedIngredient = atom<IngredientKey | null>(null);
 export const $updateSelectedIngredient = atom(
   (get) => get($selectedIngredient),
   (get, set, selectedIngredient: IngredientKey | null) => {
-    if (selectedIngredient === null) {
-      set($selectedIngredient, null);
-      return;
-    }
-
-    if (get($selectedIngredient) === selectedIngredient) {
+    if (selectedIngredient === null || get($selectedIngredient) === selectedIngredient) {
       set($selectedIngredient, null);
       return;
     }

--- a/src/store/ingredient.ts
+++ b/src/store/ingredient.ts
@@ -42,13 +42,8 @@ export const $updateSelectedIngredients = atom(
 export const $selectedIngredient = atom<IngredientKey | null>(null);
 export const $updateSelectedIngredient = atom(
   (get) => get($selectedIngredient),
-  (get, set, selectedIngredient: IngredientKey | []) => {
-    if (Array.isArray(selectedIngredient)) {
-      set($selectedIngredients, selectedIngredient);
-      return;
-    }
-
-    if (selectedIngredient === get($selectedIngredient)) {
+  (_get, set, selectedIngredient: IngredientKey | null) => {
+    if (selectedIngredient === null) {
       set($selectedIngredient, null);
       return;
     }

--- a/src/types/myActivity.ts
+++ b/src/types/myActivity.ts
@@ -7,6 +7,7 @@ export interface ReceivedIngredient {
   ingredient: IngredientKey;
   message: string;
   access: boolean;
+  supportedTteokgukId: number;
 }
 
 export interface MySupportedTteokguk {


### PR DESCRIPTION
## 📝 작업 내용

1. 재료 추가 모달 이슈
- 재료 선택하고 모달을 닫았다 열었을때 이전에 선택된 재료가 남아있는 이슈 수정
- 재료 토글이 안되었는데 토글 되도록 변경
- 재료 선택시 재고 숫자가 바로 줄어들었는데, 추가 완료되기 전까지는 차감되지 않게 수정

2. 활동 내역 페이지의 받은 재료에서 [내 떡국 방문]을 누르면 타인 떡국 페이지로 이동하는 문제 해결

close #117 
close #118 
